### PR TITLE
Update DB config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Environment configuration for local development
+DB_PASSWORD=YOUR_DB_PASSWORD
+DATABASE_URL=postgres://doadmin:${DB_PASSWORD}@dbaas-db-4409310-do-user-18540873-0.f.db.ondigitalocean.com:25060/defaultdb?sslmode=require

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ npx serve
 
 3. Visit `http://localhost:8000`
 
+### Environment Variables
+Create a `.env` file in the project root with your database credentials. The file is ignored by git.
+
+```
+DB_PASSWORD=YOUR_DB_PASSWORD
+DATABASE_URL=postgres://doadmin:${DB_PASSWORD}@dbaas-db-4409310-do-user-18540873-0.f.db.ondigitalocean.com:25060/defaultdb?sslmode=require
+```
+
 ### Making Changes
 1. **Static Content**
    - Edit HTML files directly

--- a/api/test-db.js
+++ b/api/test-db.js
@@ -4,10 +4,10 @@ const fs = require('fs');
 const path = require('path');
 
 const config = {
-    host: 'dbaas-db-8731719-do-user-18540873-0.h.db.ondigitalocean.com', // Using non-private hostname
+    host: 'dbaas-db-4409310-do-user-18540873-0.f.db.ondigitalocean.com', // Using non-private hostname
     port: 25060,
     database: 'defaultdb',
-    username: 'mxbikes-net',
+    username: 'doadmin',
     password: process.env.DB_PASSWORD
 };
 

--- a/app.dev.yaml
+++ b/app.dev.yaml
@@ -18,7 +18,7 @@ services:
     # Environment configuration
     envs:
       - key: DATABASE_URL
-        value: postgres://mxbikes-net:${DB_PASSWORD}@private-dbaas-db-8731719-do-user-18540873-0.h.db.ondigitalocean.com:25060/defaultdb?sslmode=require
+        value: postgres://doadmin:${DB_PASSWORD}@dbaas-db-4409310-do-user-18540873-0.f.db.ondigitalocean.com:25060/defaultdb?sslmode=require
       - key: NODE_ENV
         value: development
       - key: ALLOWED_ORIGINS

--- a/app.yaml
+++ b/app.yaml
@@ -18,7 +18,7 @@ services:
     # Environment configuration
     envs:
       - key: DATABASE_URL
-        value: postgres://mxbikes-net:${DB_PASSWORD}@private-dbaas-db-8731719-do-user-18540873-0.h.db.ondigitalocean.com:25060/defaultdb?sslmode=require
+        value: postgres://doadmin:${DB_PASSWORD}@dbaas-db-4409310-do-user-18540873-0.f.db.ondigitalocean.com:25060/defaultdb?sslmode=require
       - key: NODE_ENV
         value: production
       - key: ALLOWED_ORIGINS


### PR DESCRIPTION
## Summary
- switch to new DigitalOcean database host
- provide `.env.example` for local environment variables
- document DB credentials setup in the README

## Testing
- `npm install --silent` *(fails: MODULE_NOT_FOUND for 'sequelize')*

------
https://chatgpt.com/codex/tasks/task_e_686926ba1d10832a8910ac0d62aab367