### PR TITLE
Add API environment setup notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,24 @@ npx serve
 
 3. Visit `http://localhost:8000`
 
+#### API Environment Variables
+To run the API server locally, set the following environment variables:
+
+```bash
+export DB_HOST="<database host>"
+export DB_PORT=25060
+export DB_NAME=defaultdb
+export DB_USER="<database user>"
+export DB_PASSWORD="<database password>"
+export DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=require"
+```
+
+With these variables set, you can test the connection with:
+
+```bash
+node api/test-db.js
+```
+
 ### Making Changes
 1. **Static Content**
    - Edit HTML files directly

--- a/api/test-db.js
+++ b/api/test-db.js
@@ -4,10 +4,10 @@ const fs = require('fs');
 const path = require('path');
 
 const config = {
-    host: 'dbaas-db-8731719-do-user-18540873-0.h.db.ondigitalocean.com', // Using non-private hostname
-    port: 25060,
-    database: 'defaultdb',
-    username: 'mxbikes-net',
+    host: process.env.DB_HOST || 'dbaas-db-8731719-do-user-18540873-0.h.db.ondigitalocean.com',
+    port: process.env.DB_PORT || 25060,
+    database: process.env.DB_NAME || 'defaultdb',
+    username: process.env.DB_USER || 'mxbikes-net',
     password: process.env.DB_PASSWORD
 };
 


### PR DESCRIPTION
## Summary
- make `api/test-db.js` configurable via environment variables
- document environment setup for local API development

## Testing
- `node api/test-db.js` *(fails: ENETUNREACH 143.198.143.159:25060)*

------
https://chatgpt.com/codex/tasks/task_e_686926ba1d10832a8910ac0d62aab367